### PR TITLE
Default to the "en" locale when the system locale is not supported

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,15 +177,17 @@ class NotesRoot extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           locale: appInfo.customLocale != -1
               ? supportedLocales[appInfo.customLocale]
-              : Locale("en"),
+              : null,
           localeResolutionCallback:
               (Locale locale, Iterable<Locale> supportedLocales) {
             for (var supportedLocale in supportedLocales) {
-              if (locale.toString() == supportedLocale.toString()) {
+              if (locale.toString().split("_")[0] == supportedLocale.toString()) {
                 return supportedLocale;
-              }
+              }  
             }
-            return locale;
+            print("The " + locale.toString() + " is not supported");
+            print("Defaulting to the en locale");
+            return Locale("en");
           },
           theme: appInfo.followSystemTheme
               ? CustomThemes.light(appInfo)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,7 +177,7 @@ class NotesRoot extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           locale: appInfo.customLocale != -1
               ? supportedLocales[appInfo.customLocale]
-              : null,
+              : Locale("en"),
           localeResolutionCallback:
               (Locale locale, Iterable<Locale> supportedLocales) {
             for (var supportedLocale in supportedLocales) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,11 +181,11 @@ class NotesRoot extends StatelessWidget {
           localeResolutionCallback:
               (Locale locale, Iterable<Locale> supportedLocales) {
             for (var supportedLocale in supportedLocales) {
-              if (locale.toString().split("_")[0] == supportedLocale.toString()) {
+              if (locale.languageCode == supportedLocale.languageCode) {
                 return supportedLocale;
               }  
             }
-            print("The " + locale.toString() + " is not supported");
+            print("The " + locale.toString() + " locale is not supported");
             print("Defaulting to the en locale");
             return Locale("en");
           },


### PR DESCRIPTION
Instead of defaulting to null and crashing the app, the locale will now be defaulted to the "en" locale.